### PR TITLE
add dynamic Partners (שותפים) CRUD management

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -99,7 +99,7 @@ function ThemedApp() {
               <Route path="cms" element={<CMSPage />} />
               <Route path="users" element={<UserManagementPage />} />
               <Route path="roles" element={<Navigate to="/admin/users?tab=roles" replace />} />
-              <Route path="audit-log" element={<AuditLogPage />} />
+<Route path="audit-log" element={<AuditLogPage />} />
             </Route>
 
             <Route path="*" element={<Navigate to="/public" replace />} />

--- a/frontend/src/features/admin/pages/CMSPage.jsx
+++ b/frontend/src/features/admin/pages/CMSPage.jsx
@@ -9,12 +9,14 @@ import InfoIcon from '@mui/icons-material/Info';
 import AutoStoriesIcon from '@mui/icons-material/AutoStories';
 import NewspaperIcon from '@mui/icons-material/Newspaper';
 import GroupsIcon from '@mui/icons-material/Groups';
+import HandshakeIcon from '@mui/icons-material/Handshake';
 import PreviewIcon from '@mui/icons-material/Preview';
 import PublicHomePageHomeTab from './PublicHomePageHomeTab';
 import PublicHomePageLearnTogetherTab from './PublicHomePageLearnTogetherTab';
 import PublicHomePageInspirationStoriesTab from './PublicHomePageInspirationStoriesTab';
 import PublicHomePagePressCoverageTab from './PublicHomePagePressCoverageTab';
 import PublicHomePageTeamTab from './PublicHomePageTeamTab';
+import PartnersManagementPage from './PartnersManagementPage';
 
 const TABS = [
   { key: 'home', label: 'Home', icon: <HomeIcon />, Component: PublicHomePageHomeTab },
@@ -36,6 +38,12 @@ const TABS = [
     label: 'Team',
     icon: <GroupsIcon />,
     Component: PublicHomePageTeamTab,
+  },
+  {
+    key: 'partners',
+    label: 'Partners',
+    icon: <HandshakeIcon />,
+    Component: PartnersManagementPage,
   },
 ];
 

--- a/frontend/src/features/admin/pages/PartnersManagementPage.jsx
+++ b/frontend/src/features/admin/pages/PartnersManagementPage.jsx
@@ -1,0 +1,463 @@
+import { useEffect, useMemo, useState } from 'react';
+import { doc, getDoc, setDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { db, auth } from '../../../firebase';
+import { logAuditEvent } from '../services/auditService';
+import {
+  PUBLIC_PAGES_COLLECTION,
+  PUBLIC_HOME_DOC_ID,
+  DEFAULT_PARTNERS,
+  mergePartners,
+} from '../../public/services/publicPagesService';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import AddIcon from '@mui/icons-material/Add';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import HandshakeIcon from '@mui/icons-material/Handshake';
+import PreviewIcon from '@mui/icons-material/Preview';
+
+const LIMITS = {
+  name: 80,
+  logoUrl: 500,
+  description: 400,
+};
+
+function generatePartnerId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `partner-${crypto.randomUUID()}`;
+  }
+  return `partner-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isValidUrlOrEmpty(value) {
+  if (!value) return true;
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  if (trimmed.startsWith('/')) return true;
+  try {
+    new URL(trimmed);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function reindexOrder(list) {
+  return list.map((item, index) => ({ ...item, order: index }));
+}
+
+function emptyDraft() {
+  return { id: '', name: '', logoUrl: '', description: '', order: 0 };
+}
+
+export default function PartnersManagementPage() {
+  const [loading, setLoading] = useState(true);
+  const [partners, setPartners] = useState([]);
+  const [toast, setToast] = useState({ open: false, severity: 'success', message: '' });
+
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editorMode, setEditorMode] = useState('create');
+  const [draft, setDraft] = useState(emptyDraft);
+  const [submitted, setSubmitted] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      setLoading(true);
+      try {
+        const ref = doc(db, PUBLIC_PAGES_COLLECTION, PUBLIC_HOME_DOC_ID);
+        const snap = await getDoc(ref);
+        const seed = DEFAULT_PARTNERS.map((p) => ({ ...p }));
+        if (!snap.exists()) {
+          await setDoc(ref, {
+            partners: seed,
+            updatedAt: serverTimestamp(),
+            updatedBy: 'system-seed',
+          });
+          if (active) setPartners(seed);
+        } else {
+          const data = snap.data() || {};
+          if (!Array.isArray(data.partners)) {
+            await updateDoc(ref, {
+              partners: seed,
+              updatedAt: serverTimestamp(),
+              updatedBy: 'system-seed',
+            });
+            if (active) setPartners(seed);
+          } else if (active) {
+            setPartners(mergePartners(data.partners));
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load partners:', err);
+        if (active) {
+          setToast({ open: true, severity: 'error', message: 'Failed to load partners.' });
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    load();
+    return () => { active = false; };
+  }, []);
+
+  const errors = useMemo(() => {
+    const next = {};
+    if (!draft.name.trim()) next.name = 'Name is required.';
+    if (!isValidUrlOrEmpty(draft.logoUrl)) next.logoUrl = 'Invalid URL.';
+    if (!draft.description.trim()) next.description = 'Description is required.';
+    return next;
+  }, [draft]);
+
+  const hasErrors = Object.keys(errors).length > 0;
+
+  function openCreate() {
+    setEditorMode('create');
+    setDraft({ ...emptyDraft(), order: partners.length });
+    setSubmitted(false);
+    setEditorOpen(true);
+  }
+
+  function openEdit(partner) {
+    setEditorMode('edit');
+    setDraft({
+      id: partner.id,
+      name: partner.name || '',
+      logoUrl: partner.logoUrl || '',
+      description: partner.description || '',
+      order: partner.order ?? 0,
+    });
+    setSubmitted(false);
+    setEditorOpen(true);
+  }
+
+  function closeEditor() {
+    if (saving) return;
+    setEditorOpen(false);
+  }
+
+  function setField(key, value) {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function persistPartners(nextPartners, audit) {
+    const user = auth.currentUser;
+    const updatedBy = user?.email || user?.uid || '';
+    const ref = doc(db, PUBLIC_PAGES_COLLECTION, PUBLIC_HOME_DOC_ID);
+    await updateDoc(ref, {
+      partners: nextPartners.map((p) => ({
+        id: p.id,
+        name: p.name,
+        logoUrl: p.logoUrl,
+        description: p.description,
+        order: p.order,
+      })),
+      updatedAt: serverTimestamp(),
+      updatedBy,
+    });
+    if (audit) {
+      await logAuditEvent({
+        actionType: audit.actionType,
+        targetId: `${PUBLIC_PAGES_COLLECTION}/${PUBLIC_HOME_DOC_ID}`,
+        details: { section: 'partners', partnerId: audit.partnerId, change: audit.change },
+      });
+    }
+    setPartners(nextPartners);
+  }
+
+  async function handleSave() {
+    setSubmitted(true);
+    if (hasErrors) return;
+    setSaving(true);
+    try {
+      const clean = {
+        id: draft.id || generatePartnerId(),
+        name: draft.name.trim(),
+        logoUrl: draft.logoUrl.trim(),
+        description: draft.description.trim(),
+        order: draft.order,
+      };
+      let next;
+      let audit;
+      if (editorMode === 'create') {
+        next = reindexOrder([...partners, clean]);
+        audit = { actionType: 'CREATE_PUBLIC_HOME_PARTNER', partnerId: clean.id, change: 'create' };
+      } else {
+        next = partners.map((p) => (p.id === clean.id ? clean : p));
+        audit = { actionType: 'UPDATE_PUBLIC_HOME_PARTNER', partnerId: clean.id, change: 'update' };
+      }
+      await persistPartners(next, audit);
+      setEditorOpen(false);
+      setToast({
+        open: true,
+        severity: 'success',
+        message: editorMode === 'create' ? 'Partner added.' : 'Partner updated.',
+      });
+    } catch (err) {
+      console.error('Failed to save partner:', err);
+      setToast({ open: true, severity: 'error', message: 'Save failed. Please try again.' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    const id = confirmDeleteId;
+    if (!id) return;
+    setDeleting(true);
+    try {
+      const next = reindexOrder(partners.filter((p) => p.id !== id));
+      await persistPartners(next, {
+        actionType: 'DELETE_PUBLIC_HOME_PARTNER',
+        partnerId: id,
+        change: 'delete',
+      });
+      setConfirmDeleteId(null);
+      setToast({ open: true, severity: 'success', message: 'Partner deleted.' });
+    } catch (err) {
+      console.error('Failed to delete partner:', err);
+      setToast({ open: true, severity: 'error', message: 'Delete failed. Please try again.' });
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function handleMove(index, direction) {
+    const swapIndex = index + direction;
+    if (swapIndex < 0 || swapIndex >= partners.length) return;
+    const next = [...partners];
+    [next[index], next[swapIndex]] = [next[swapIndex], next[index]];
+    const reindexed = reindexOrder(next);
+    try {
+      await persistPartners(reindexed, null);
+    } catch (err) {
+      console.error('Failed to reorder partners:', err);
+      setToast({ open: true, severity: 'error', message: 'Reorder failed.' });
+    }
+  }
+
+  function showError(field) {
+    return submitted && Boolean(errors[field]);
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ pb: 12 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 3, gap: 2 }}>
+        <Box>
+          <Typography variant="h4">Partners Management — ניהול שותפים</Typography>
+          <Typography variant="subtitle1" sx={{ mt: 0.5 }}>
+            Manage the partner cards shown in the "השותפים שלנו" section on the public home page.
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1, flexShrink: 0 }}>
+          <Button
+            variant="outlined"
+            startIcon={<PreviewIcon />}
+            component="a"
+            href="/public#medical-partners"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Preview
+          </Button>
+          <Button variant="contained" startIcon={<AddIcon />} onClick={openCreate}>
+            Add Partner
+          </Button>
+        </Box>
+      </Box>
+
+      <Paper sx={{ p: 3 }}>
+        {partners.length === 0 ? (
+          <Box sx={{ py: 6, textAlign: 'center' }}>
+            <HandshakeIcon sx={{ fontSize: 48, color: 'text.disabled', mb: 1 }} />
+            <Typography color="text.secondary">No partners yet. Click "Add Partner" to get started.</Typography>
+          </Box>
+        ) : (
+          <Stack spacing={1.5}>
+            {partners.map((p, index) => (
+              <Paper
+                key={p.id}
+                variant="outlined"
+                sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 2 }}
+              >
+                {/* Logo preview */}
+                <Box
+                  sx={{
+                    width: 56,
+                    height: 56,
+                    flexShrink: 0,
+                    borderRadius: 2,
+                    overflow: 'hidden',
+                    bgcolor: 'grey.100',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  {p.logoUrl ? (
+                    <img
+                      src={p.logoUrl}
+                      alt={p.name}
+                      style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+                    />
+                  ) : (
+                    <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 700 }}>
+                      {(p.name || '?').slice(0, 2)}
+                    </Typography>
+                  )}
+                </Box>
+
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 700 }} noWrap>
+                    {p.name || '—'}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      display: '-webkit-box',
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: 'vertical',
+                    }}
+                  >
+                    {p.description}
+                  </Typography>
+                </Box>
+
+                {/* Reorder */}
+                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                  <IconButton size="small" onClick={() => handleMove(index, -1)} disabled={index === 0} aria-label="Move up">
+                    <ArrowUpwardIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => handleMove(index, 1)} disabled={index === partners.length - 1} aria-label="Move down">
+                    <ArrowDownwardIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+
+                <IconButton onClick={() => openEdit(p)} aria-label="Edit partner">
+                  <EditIcon />
+                </IconButton>
+                <IconButton onClick={() => setConfirmDeleteId(p.id)} aria-label="Delete partner" color="error">
+                  <DeleteOutlineIcon />
+                </IconButton>
+              </Paper>
+            ))}
+          </Stack>
+        )}
+      </Paper>
+
+      {/* Create / Edit dialog */}
+      <Dialog open={editorOpen} onClose={closeEditor} fullWidth maxWidth="sm">
+        <DialogTitle>{editorMode === 'create' ? 'Add Partner' : 'Edit Partner'}</DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={2.5} sx={{ mt: 1 }}>
+            <TextField
+              label="Partner Name (שם השותף) *"
+              value={draft.name}
+              onChange={(e) => setField('name', e.target.value)}
+              inputProps={{ maxLength: LIMITS.name }}
+              error={showError('name')}
+              helperText={(showError('name') && errors.name) || `${draft.name.length} / ${LIMITS.name}`}
+              required
+              fullWidth
+            />
+            <TextField
+              label="Logo URL"
+              value={draft.logoUrl}
+              onChange={(e) => setField('logoUrl', e.target.value)}
+              inputProps={{ maxLength: LIMITS.logoUrl }}
+              error={showError('logoUrl')}
+              helperText={
+                (showError('logoUrl') && errors.logoUrl) ||
+                'Direct image URL (https://…). Leave empty to show initials.'
+              }
+              fullWidth
+            />
+            <TextField
+              label="Description (תיאור קצר) *"
+              value={draft.description}
+              onChange={(e) => setField('description', e.target.value)}
+              inputProps={{ maxLength: LIMITS.description }}
+              error={showError('description')}
+              helperText={(showError('description') && errors.description) || `${draft.description.length} / ${LIMITS.description}`}
+              multiline
+              minRows={3}
+              required
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeEditor} disabled={saving}>
+            Cancel
+          </Button>
+          <Button variant="contained" onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirm dialog */}
+      <Dialog open={Boolean(confirmDeleteId)} onClose={() => !deleting && setConfirmDeleteId(null)}>
+        <DialogTitle>Delete this partner?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary">
+            This action cannot be undone. The partner card will be removed from the public website.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDeleteId(null)} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button onClick={handleDelete} color="error" variant="contained" disabled={deleting}>
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={3500}
+        onClose={() => setToast((prev) => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={toast.severity}
+          onClose={() => setToast((prev) => ({ ...prev, open: false }))}
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          {toast.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/frontend/src/features/public/components/MedicalPartnersSection.jsx
+++ b/frontend/src/features/public/components/MedicalPartnersSection.jsx
@@ -1,10 +1,5 @@
-import { useMemo, useState } from 'react';
-import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
-import { MEDICAL_PARTNERS } from '../constants/medicalPartners';
-import MedicalPartnerModal from './MedicalPartnerModal';
 import PublicSectionHeading from './PublicSectionHeading';
 import { usePublicLocale } from '../context/PublicLocaleContext';
-import { localizeMedicalPartner } from '../i18n/publicHomeContentLocalization';
 import '../styles/public-medical-partners-section.css';
 
 function CardDivider() {
@@ -17,85 +12,56 @@ function CardDivider() {
   );
 }
 
-export default function MedicalPartnersSection() {
-  const { locale, t } = usePublicLocale();
-  const [selectedPartnerId, setSelectedPartnerId] = useState(null);
-  const localizedPartners = useMemo(
-    () => MEDICAL_PARTNERS.map((partner) => localizeMedicalPartner(partner, locale)),
-    [locale],
-  );
-  const selectedPartner = localizedPartners.find((partner) => partner.id === selectedPartnerId) || null;
-
-  function handleOpenModal(partner) {
-    return function onClick(event) {
-      event.preventDefault();
-      setSelectedPartnerId(partner.id);
-    };
-  }
-
-  function handleCloseModal() {
-    setSelectedPartnerId(null);
-  }
+export default function MedicalPartnersSection({ partners = [] }) {
+  const { t } = usePublicLocale();
 
   return (
-    <>
-      <section
-        className="public-section public-section--medical-partners"
-        id="medical-partners"
-        aria-labelledby="medical-partners-title"
-      >
-        <div className="medical-partners__decor" aria-hidden="true">
-          <span className="medical-partners__dots medical-partners__dots--mesh" />
-          <span className="medical-partners__blob medical-partners__blob--pink" />
-          <span className="medical-partners__blob medical-partners__blob--lavender" />
-          <span className="medical-partners__blob medical-partners__blob--purple" />
-          <span className="medical-partners__dots medical-partners__dots--one" />
-          <span className="medical-partners__dots medical-partners__dots--two" />
-        </div>
+    <section
+      className="public-section public-section--medical-partners"
+      id="medical-partners"
+      aria-labelledby="medical-partners-title"
+    >
+      <div className="medical-partners__decor" aria-hidden="true">
+        <span className="medical-partners__dots medical-partners__dots--mesh" />
+        <span className="medical-partners__blob medical-partners__blob--pink" />
+        <span className="medical-partners__blob medical-partners__blob--lavender" />
+        <span className="medical-partners__blob medical-partners__blob--purple" />
+        <span className="medical-partners__dots medical-partners__dots--one" />
+        <span className="medical-partners__dots medical-partners__dots--two" />
+      </div>
 
-        <div className="medical-partners__inner">
-          <PublicSectionHeading
-            className="medical-partners__heading-wrap"
-            eyebrow={t('medicalEyebrow')}
-            title={t('medicalTitle')}
-            titleId="medical-partners-title"
-            subtitle={t('medicalSubtitle')}
-          />
+      <div className="medical-partners__inner">
+        <PublicSectionHeading
+          className="medical-partners__heading-wrap"
+          eyebrow={t('medicalEyebrow')}
+          title={t('medicalTitle')}
+          titleId="medical-partners-title"
+          subtitle={t('medicalSubtitle')}
+        />
 
-          <div className="medical-partners__grid stagger-children">
-            {localizedPartners.map((partner) => (
-              <article className="medical-partners__card reveal" key={partner.id}>
-                <div
-                  className={`medical-partner-logo-wrap${
-                    partner.id === 'assuta-ashdod' ? ' medical-partner-logo-wrap--assuta' : ''
-                  }`}
-                >
+        <div className="medical-partners__scroll-track stagger-children">
+          {partners.map((partner) => (
+            <article className="medical-partners__card reveal" key={partner.id}>
+              <div className="medical-partner-logo-wrap">
+                {partner.logoUrl ? (
                   <img
                     className="medical-partner-logo"
-                    src={partner.logoSrc}
+                    src={partner.logoUrl}
                     alt={`${t('medicalLogoAlt')} ${partner.name}`}
                     loading="lazy"
                     decoding="async"
                   />
-                </div>
-                <h3 className="medical-partners__name">{partner.name}</h3>
-                <CardDivider />
-                <p className="medical-partners__excerpt">{partner.shortDescription}</p>
-                <button type="button" className="medical-partners__more" onClick={handleOpenModal(partner)}>
-                  <span className="medical-partners__more-label">{t('medicalMore')}</span>
-                  <span className="medical-partners__more-icon" aria-hidden="true">
-                    <ArrowBackRoundedIcon fontSize="inherit" />
-                  </span>
-                </button>
-              </article>
-            ))}
-          </div>
+                ) : (
+                  <span className="medical-partner-logo-placeholder">{partner.name.slice(0, 2)}</span>
+                )}
+              </div>
+              <h3 className="medical-partners__name">{partner.name}</h3>
+              <CardDivider />
+              <p className="medical-partners__excerpt">{partner.description}</p>
+            </article>
+          ))}
         </div>
-      </section>
-
-      {selectedPartner ? (
-        <MedicalPartnerModal partner={selectedPartner} isOpen onClose={handleCloseModal} />
-      ) : null}
-    </>
+      </div>
+    </section>
   );
 }

--- a/frontend/src/features/public/pages/PublicHomePage.jsx
+++ b/frontend/src/features/public/pages/PublicHomePage.jsx
@@ -120,7 +120,7 @@ function PublicHomePageContent() {
         <EventsPreviewSection events={content.events} isLoading={loading} hasError={error} />
         <CommunitySupportCta onDonationClick={() => setIsDonationModalOpen(true)} />
         <TeamSection members={publicHomeDoc.teamMembers} />
-        <MedicalPartnersSection />
+        <MedicalPartnersSection partners={publicHomeDoc.partners} />
         <ContactSection contact={content.contact} organization={content.organization} />
       </main>
       <PublicFooter organization={content.organization} contact={content.contact} />

--- a/frontend/src/features/public/services/publicPagesService.js
+++ b/frontend/src/features/public/services/publicPagesService.js
@@ -1,6 +1,10 @@
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../../../firebase';
 import heroWomenSupport from '../../../assets/images/hero-women-support.png';
+import assutaLogo from '../../../assets/images/assuta.png';
+import ichilovLogo from '../../../assets/images/ichilov.png';
+import barzilaiLogo from '../../../assets/images/barzilai-logo.jpg';
+import shamirLogo from '../../../assets/images/shamir.png';
 import {
   isKnownAboutUsIconKey,
   DEFAULT_ABOUT_US_ICON_KEY,
@@ -543,6 +547,59 @@ export function mergeLearnTogether(learnTogether) {
   };
 }
 
+export const DEFAULT_PARTNERS = [
+  {
+    id: 'seed-partner-assuta',
+    name: 'אסותא אשדוד',
+    logoUrl: assutaLogo,
+    description: 'בית חולים פרטי המעניק ליווי רפואי מתקדם ושירותי בריאות מקיפים לנשים ולמשפחותיהן.',
+    order: 0,
+  },
+  {
+    id: 'seed-partner-ichilov',
+    name: 'סוראסקי איכילוב',
+    logoUrl: ichilovLogo,
+    description: 'מרכז רפואי מוביל המציע מגוון שירותים אונקולוגיים וליווי מקצועי לאורך הטיפול.',
+    order: 1,
+  },
+  {
+    id: 'seed-partner-barzilai',
+    name: 'ברזילי',
+    logoUrl: barzilaiLogo,
+    description: 'בית חולים ממשלתי עם מחלקה אונקולוגית מתקדמת ושירותי תמיכה לנשים.',
+    order: 2,
+  },
+  {
+    id: 'seed-partner-assaf',
+    name: 'אסף הרופא',
+    logoUrl: shamirLogo,
+    description: 'מרכז רפואי גדול עם מומחיות בטיפולים אונקולוגיים ותמיכה הוליסטית.',
+    order: 3,
+  },
+];
+
+function mergePartner(partner, index) {
+  const safe = partner && typeof partner === 'object' ? partner : {};
+  const orderRaw = typeof safe.order === 'number' ? safe.order : Number(safe.order);
+  const order = Number.isFinite(orderRaw) ? orderRaw : index;
+  return {
+    id: safeString(safe.id) || `partner-${index}`,
+    name: safeString(safe.name),
+    logoUrl: safeString(safe.logoUrl) || (DEFAULT_PARTNERS.find((d) => d.id === safeString(safe.id))?.logoUrl ?? ''),
+    description: safeString(safe.description),
+    order,
+  };
+}
+
+export function mergePartners(value) {
+  if (!Array.isArray(value) || value.length === 0) {
+    return DEFAULT_PARTNERS.map((p) => ({ ...p }));
+  }
+  return value
+    .map((partner, index) => mergePartner(partner, index))
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}
+
 export function mergeHero(hero) {
   const safeHero = hero && typeof hero === 'object' ? hero : {};
   return {
@@ -600,6 +657,7 @@ export function getDefaultPublicHomeDoc() {
     pressCoverage: DEFAULT_PRESS_COVERAGE.map((p) => ({ ...p })),
     statistics: DEFAULT_STATISTICS.map((s) => ({ ...s })),
     teamMembers: DEFAULT_TEAM_MEMBERS.map((m) => ({ ...m })),
+    partners: DEFAULT_PARTNERS.map((p) => ({ ...p })),
     updatedAt: null,
     updatedBy: '',
   };
@@ -621,6 +679,7 @@ export async function getPublicHomeDoc() {
       pressCoverage: mergePressCoverage(data.pressCoverage),
       statistics: mergeStatistics(data.statistics),
       teamMembers: mergeTeamMembers(data.teamMembers),
+      partners: mergePartners(data.partners),
     };
   } catch (error) {
     console.warn('[publicPagesService] Failed to load public_pages/home, using defaults.', error);

--- a/frontend/src/features/public/styles/public-medical-partners-section.css
+++ b/frontend/src/features/public/styles/public-medical-partners-section.css
@@ -108,23 +108,35 @@
   line-height: 1.8;
 }
 
-.public-homepage .public-section--medical-partners .medical-partners__grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-auto-rows: 1fr;
+.public-homepage .public-section--medical-partners .medical-partners__scroll-track {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
   align-items: stretch;
   gap: var(--public-grid-gap, clamp(20px, 2.4vw, 28px));
-  width: min(100%, var(--public-grid-max, 1280px));
-  max-width: 100%;
-  margin-inline: auto;
+  width: 100%;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  padding-block-end: 8px; /* room for the scrollbar (hidden but some browsers need space) */
+  /* hide scrollbar cross-browser */
+  scrollbar-width: none;
 }
+
+.public-homepage .public-section--medical-partners .medical-partners__scroll-track::-webkit-scrollbar {
+  display: none;
+}
+
+/* In RTL the flex row already starts from the right — no extra change needed */
 
 .public-homepage .public-section--medical-partners .medical-partners__card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100%;
-  padding-block-start: max(0px, calc(clamp(16px, 1.8vw, 22px) - 20px));
+  flex: 0 0 clamp(240px, 26vw, 300px);
+  scroll-snap-align: start;
+  padding-block-start: clamp(16px, 1.8vw, 22px);
   padding-block-end: clamp(26px, 2.8vw, 32px);
   padding-inline: clamp(18px, 2vw, 26px);
   text-align: center;
@@ -192,59 +204,6 @@
   overflow: hidden;
 }
 
-.public-homepage .public-section--medical-partners .medical-partners__more {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-block-start: auto;
-  padding-block: 0.48rem;
-  padding-inline: 0.95rem 0.8rem;
-  color: var(--mp-purple);
-  font-family: inherit;
-  font-size: 0.84rem;
-  font-weight: 700;
-  background: var(--mp-pink-soft);
-  border: 1px solid rgba(217, 70, 161, 0.28);
-  border-radius: 999px;
-  cursor: pointer;
-  transition:
-    color 300ms ease,
-    background 300ms ease,
-    border-color 300ms ease,
-    box-shadow 300ms ease,
-    transform 300ms ease;
-}
-
-.public-homepage .public-section--medical-partners .medical-partners__more-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.35rem;
-  height: 1.35rem;
-  color: var(--mp-purple);
-  background: #ffffff;
-  border-radius: 50%;
-  box-shadow: 0 2px 8px rgba(91, 30, 140, 0.1);
-}
-
-.public-homepage .public-section--medical-partners .medical-partners__more-icon svg {
-  width: 0.85rem;
-  height: 0.85rem;
-}
-
-.public-homepage .public-section--medical-partners .medical-partners__more:hover,
-.public-homepage .public-section--medical-partners .medical-partners__more:focus-visible {
-  color: #ffffff;
-  background: linear-gradient(135deg, var(--mp-pink) 0%, var(--mp-purple-mid) 100%);
-  border-color: transparent;
-  box-shadow: 0 10px 22px rgba(217, 70, 161, 0.28);
-  transform: translateY(-2px);
-}
-
-.public-homepage .public-section--medical-partners .medical-partners__more:hover .medical-partners__more-icon,
-.public-homepage .public-section--medical-partners .medical-partners__more:focus-visible .medical-partners__more-icon {
-  color: var(--mp-pink);
-}
 
 @media (max-width: 640px) {
   .public-homepage .public-section.public-section--medical-partners {
@@ -253,9 +212,21 @@
   }
 }
 
+.public-homepage .public-section--medical-partners .medical-partner-logo-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(138, 45, 168, 0.15), rgba(217, 70, 161, 0.15));
+  color: var(--mp-purple);
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .public-homepage .public-section--medical-partners .medical-partners__card,
-  .public-homepage .public-section--medical-partners .medical-partners__more {
+  .public-homepage .public-section--medical-partners .medical-partners__card {
     transition: none;
   }
 


### PR DESCRIPTION
- Store partners in public_pages/home/partners in Firestore
- Admin: Partners tab added to CMS page with full create/read/update/delete + reorder
- Public: MedicalPartnersSection now driven by Firestore data with horizontal RTL scroll
- Seed defaults use bundled logos; mergePartner falls back to default logo when logoUrl is empty
- Removed לפרטים נוספים button and all related code